### PR TITLE
Centralize colors with helper map

### DIFF
--- a/bar_with_error.m
+++ b/bar_with_error.m
@@ -1,6 +1,7 @@
 function bar_with_error(categories, values, errLow, errHigh, color, yLabel, xLabel, titleStr, savePath)
 if nargin < 5 || isempty(color)
-    color = [0.2 0.6 0.8];
+    cmap = get_color_map();
+    color = cmap.tight; % default bar color
 end
 fig = create_hidden_figure();
 nexttile;

--- a/get_color_map.m
+++ b/get_color_map.m
@@ -1,0 +1,11 @@
+function cmap = get_color_map()
+%GET_COLOR_MAP Return a struct of common analysis colors
+%   This helper centralizes color choices used across plots so that the
+%   same quantity is drawn with a consistent color everywhere.
+
+cmap.pm25 = [0.2 0.4 0.8];    % blue
+cmap.pm10 = [0.8 0.3 0.3];    % red
+cmap.tight = [0.2 0.6 0.8];   % teal for tight envelopes
+cmap.leaky = [0.8 0.4 0.2];   % orange for leaky envelopes
+cmap.gray = [0.6 0.6 0.6];    % neutral gray
+end

--- a/plot_efficacy_scores.m
+++ b/plot_efficacy_scores.m
@@ -28,6 +28,7 @@ for i = 1:nConfigs
 end
 
 colors = lines(nConfigs);
+cmap = get_color_map();
 
 %% Panel 1: Overall Efficacy Score Ranking with Confidence Intervals
 nexttile;
@@ -81,9 +82,9 @@ hold on;
 
 % Plot tight vs leaky scores
 plot(1:nConfigs, efficacyScoreTable.tight_efficacy_score, 'o-', ...
-    'Color', [0.2 0.6 0.8], 'LineWidth', 2, 'MarkerSize', 6, 'DisplayName', 'Tight Envelope');
+    'Color', cmap.tight, 'LineWidth', 2, 'MarkerSize', 6, 'DisplayName', 'Tight Envelope');
 plot(1:nConfigs, efficacyScoreTable.leaky_efficacy_score, 's--', ...
-    'Color', [0.8 0.4 0.2], 'LineWidth', 2, 'MarkerSize', 6, 'DisplayName', 'Leaky Envelope');
+    'Color', cmap.leaky, 'LineWidth', 2, 'MarkerSize', 6, 'DisplayName', 'Leaky Envelope');
 
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
@@ -94,7 +95,7 @@ grid on;
 
 %% Panel 4: Score Range (Uncertainty) Analysis
 nexttile;
-bar(efficacyScoreTable.score_range, 'FaceColor', [0.6 0.6 0.6], 'EdgeColor', 'k');
+bar(efficacyScoreTable.score_range, 'FaceColor', cmap.gray, 'EdgeColor', 'k');
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
 ylabel('Score Range (Tight - Leaky)');

--- a/plot_penetration_analysis.m
+++ b/plot_penetration_analysis.m
@@ -13,6 +13,7 @@ figure('Position', [100 100 1400 900], 'Visible', 'off');
 
 configs = fieldnames(penetrationAnalysis);
 nConfigs = length(configs);
+cmap = get_color_map();
 
 % Penetration factors comparison
 subplot(2, 2, 1);
@@ -39,9 +40,9 @@ x = 1:nConfigs;
 width = 0.35;
 
 % Plot with error bars
-hPM25 = bar(x - width/2, pm25_factors, width, 'FaceColor', [0.2 0.4 0.8]);
+hPM25 = bar(x - width/2, pm25_factors, width, 'FaceColor', cmap.pm25);
 hold on;
-hPM10 = bar(x + width/2, pm10_factors, width, 'FaceColor', [0.8 0.3 0.3]);
+hPM10 = bar(x + width/2, pm10_factors, width, 'FaceColor', cmap.pm10);
 
 % Add error bars for bounds
 errorbar(x - width/2, pm25_factors, ...
@@ -65,9 +66,9 @@ pm10_removal = (1 - pm10_factors) * 100;
 pm25_removal_bounds = (1 - pm25_bounds) * 100;
 pm10_removal_bounds = (1 - pm10_bounds) * 100;
 
-hR25 = bar(x - width/2, pm25_removal, width, 'FaceColor', [0.2 0.4 0.8]);
+hR25 = bar(x - width/2, pm25_removal, width, 'FaceColor', cmap.pm25);
 hold on;
-hR10 = bar(x + width/2, pm10_removal, width, 'FaceColor', [0.8 0.3 0.3]);
+hR10 = bar(x + width/2, pm10_removal, width, 'FaceColor', cmap.pm10);
 
 % Add error bars for bounds
 errorbar(x - width/2, pm25_removal, ...
@@ -89,7 +90,7 @@ size_ratio = pm10_factors ./ pm25_factors;
 ratio_bounds(:,1) = pm10_bounds(:,1) ./ pm25_bounds(:,2);
 ratio_bounds(:,2) = pm10_bounds(:,2) ./ pm25_bounds(:,1);
 
-hRatio = bar(size_ratio, 'FaceColor', [0.6 0.6 0.6]);
+hRatio = bar(size_ratio, 'FaceColor', cmap.gray);
 hold on;
 errorbar(x, size_ratio, ...
     size_ratio - ratio_bounds(:,1)', ratio_bounds(:,2)' - size_ratio, ...


### PR DESCRIPTION
## Summary
- add `get_color_map` for common color definitions
- default `bar_with_error` to new tight color
- use color map in `plot_efficacy_scores` and `plot_penetration_analysis`

## Testing
- `ls | head`

------
https://chatgpt.com/codex/tasks/task_e_6888c0cf42f88327b93c27a195ee5d70