### PR TITLE
Fix IO ratio dynamics shading with NaN handling

### DIFF
--- a/plot_io_ratio_dynamics.m
+++ b/plot_io_ratio_dynamics.m
@@ -15,13 +15,19 @@ for i = 1:nConfigs
     % Plot time series with bounds
     t = 1:numel(data.io_pm25_mean);
     
-    % PM2.5 bounds
-    fill([t fliplr(t)], [data.io_pm25_tight' fliplr(data.io_pm25_leaky')], ...
+    % PM2.5 bounds -- handle NaNs to ensure the shaded area renders correctly
+    valid25 = isfinite(data.io_pm25_tight) & isfinite(data.io_pm25_leaky);
+    t25 = t(valid25);
+    fill([t25 fliplr(t25)], ...
+        [data.io_pm25_tight(valid25)' fliplr(data.io_pm25_leaky(valid25)')], ...
         [0.2 0.4 0.8], 'FaceAlpha', 0.3, 'EdgeColor', 'none');
     plot(t, data.io_pm25_mean, 'b-', 'LineWidth', 2);
     
     % PM10 bounds
-    fill([t fliplr(t)], [data.io_pm10_tight' fliplr(data.io_pm10_leaky')], ...
+    valid10 = isfinite(data.io_pm10_tight) & isfinite(data.io_pm10_leaky);
+    t10 = t(valid10);
+    fill([t10 fliplr(t10)], ...
+        [data.io_pm10_tight(valid10)' fliplr(data.io_pm10_leaky(valid10)')], ...
         [0.8 0.3 0.3], 'FaceAlpha', 0.3, 'EdgeColor', 'none');
     plot(t, data.io_pm10_mean, 'r-', 'LineWidth', 2);
     


### PR DESCRIPTION
## Summary
- ensure shading appears in indoor/outdoor ratio dynamics plots
- skip NaN values when creating fill patches for PM2.5 and PM10 bounds

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888c8e2df048327b28efe284aafd988