### PR TITLE
Fix removal efficiency error bounds

### DIFF
--- a/plot_penetration_analysis.m
+++ b/plot_penetration_analysis.m
@@ -63,8 +63,12 @@ ylim([0 1]);
 subplot(2, 2, 2);
 pm25_removal = (1 - pm25_factors) * 100;
 pm10_removal = (1 - pm10_factors) * 100;
-pm25_removal_bounds = (1 - pm25_bounds) * 100;
-pm10_removal_bounds = (1 - pm10_bounds) * 100;
+% Bounds are provided as [tightMean, leakyMean] and may not be ordered.
+% Sort penetration bounds so we can derive valid removal efficiency bounds
+pm25_pen_sorted = sort(pm25_bounds, 2);  % [lowPen, highPen]
+pm10_pen_sorted = sort(pm10_bounds, 2);
+pm25_removal_bounds = (1 - fliplr(pm25_pen_sorted)) * 100; % [minRem, maxRem]
+pm10_removal_bounds = (1 - fliplr(pm10_pen_sorted)) * 100;
 
 hR25 = bar(x - width/2, pm25_removal, width, 'FaceColor', cmap.pm25);
 hold on;

--- a/plot_trigger_response_analysis.m
+++ b/plot_trigger_response_analysis.m
@@ -194,8 +194,11 @@ ylim([0 1]);
 subplot(2, 2, 2);
 pm25_removal = (1 - pm25_factors) * 100;
 pm10_removal = (1 - pm10_factors) * 100;
-pm25_removal_bounds = (1 - pm25_bounds) * 100;
-pm10_removal_bounds = (1 - pm10_bounds) * 100;
+% Bounds come as [tightMean, leakyMean]; ensure lower bound first
+pm25_pen_sorted = sort(pm25_bounds, 2);  % ascending penetration
+pm10_pen_sorted = sort(pm10_bounds, 2);
+pm25_removal_bounds = (1 - fliplr(pm25_pen_sorted)) * 100;
+pm10_removal_bounds = (1 - fliplr(pm10_pen_sorted)) * 100;
 
 bar(x - width/2, pm25_removal, width, 'FaceColor', [0.2 0.4 0.8]);
 hold on;


### PR DESCRIPTION
## Summary
- ensure removal efficiency bounds are ordered correctly
- apply the same logic to trigger response analysis plot

## Testing
- `apt-get install -y octave` *(fails: error while configuring ca-certificates-java)*

------
https://chatgpt.com/codex/tasks/task_e_6888cbd3344c83279d10795f5fef6d80