### PR TITLE
Ensure bounds plotted correctly for temporal performance

### DIFF
--- a/analyze_temporal_patterns.m
+++ b/analyze_temporal_patterns.m
@@ -101,6 +101,10 @@ for i = 1:length(configs)
         
         temporalAnalysis.(config).performance_trend_tight = daily_averages_tight;
         temporalAnalysis.(config).performance_trend_leaky = daily_averages_leaky;
+        % Explicitly store lower and upper bounds for clarity
+        temporalAnalysis.(config).performance_trend_lower = min(daily_averages_tight, daily_averages_leaky);
+        temporalAnalysis.(config).performance_trend_upper = max(daily_averages_tight, daily_averages_leaky);
+
         temporalAnalysis.(config).performance_trend = (daily_averages_tight + daily_averages_leaky) / 2;
     else
         temporalAnalysis.(config).stability_score = NaN;

--- a/plot_temporal_patterns.m
+++ b/plot_temporal_patterns.m
@@ -16,6 +16,8 @@ configs = fieldnames(temporalAnalysis);
 subplot(2, 2, 1);
 hold on;
 colors = lines(length(configs));
+diurnalHandles = [];
+diurnalLabels = {};
 
 for i = 1:length(configs)
     config = configs{i};
@@ -26,15 +28,21 @@ for i = 1:length(configs)
                  [data.diurnal_io_ratio_lower' fliplr(data.diurnal_io_ratio_upper')], ...
                  colors(i,:), 'FaceAlpha',0.2,'EdgeColor','none');
         end
-        plot(0:23, data.diurnal_io_ratio, 'o-', 'Color', colors(i,:), ...
+        h = plot(0:23, data.diurnal_io_ratio, 'o-', 'Color', colors(i,:), ...
             'LineWidth', 2, 'MarkerSize', 6);
+        diurnalHandles(end+1) = h; %#ok<AGROW>
+        diurnalLabels{end+1} = strrep(config, '_', ' '); %#ok<AGROW>
     end
 end
 
 xlabel('Hour of Day');
 ylabel('Average I/O Ratio');
 title('Diurnal Pattern of Filtration Performance');
-legend(strrep(configs, '_', ' '), 'Location', 'best');
+if ~isempty(diurnalHandles)
+    legend(diurnalHandles, diurnalLabels, 'Location', 'best');
+else
+    legend(strrep(configs, '_', ' '), 'Location', 'best');
+end
 grid on;
 xlim([-0.5 23.5]);
 
@@ -75,25 +83,38 @@ grid on;
 subplot(2, 2, [3 4]);
 hold on;
 
+lineHandles = [];
+legendLabels = {};
 for i = 1:length(configs)
     config = configs{i};
     data = temporalAnalysis.(config);
-    if isfield(data, 'performance_trend')
+    if isfield(data, 'performance_trend') && ~isempty(data.performance_trend)
         days = 1:length(data.performance_trend);
-        if isfield(data, 'performance_trend_tight')
+        if isfield(data, 'performance_trend_lower')
             fill([days fliplr(days)], ...
-                 [data.performance_trend_tight fliplr(data.performance_trend_leaky)], ...
+                 [data.performance_trend_lower fliplr(data.performance_trend_upper)], ...
+                 colors(i,:), 'FaceAlpha',0.2,'EdgeColor','none');
+        elseif isfield(data, 'performance_trend_tight')
+            lowerVals = min(data.performance_trend_tight, data.performance_trend_leaky);
+            upperVals = max(data.performance_trend_tight, data.performance_trend_leaky);
+            fill([days fliplr(days)], [lowerVals fliplr(upperVals)], ...
                  colors(i,:), 'FaceAlpha',0.2,'EdgeColor','none');
         end
-        plot(days, data.performance_trend, 'o-', 'Color', colors(i,:), ...
-            'LineWidth', 1.5, 'MarkerSize', 4);
+        h = plot(days, data.performance_trend, 'o-', 'Color', colors(i,:), ...
+                 'LineWidth', 1.5, 'MarkerSize', 4);
+        lineHandles(end+1) = h; %#ok<AGROW>
+        legendLabels{end+1} = strrep(config, '_', ' '); %#ok<AGROW>
     end
 end
 
 xlabel('Day');
 ylabel('Daily Average I/O Ratio');
 title('Performance Trend Over Time');
-legend(strrep(configs, '_', ' '), 'Location', 'best');
+if ~isempty(lineHandles)
+    legend(lineHandles, legendLabels, 'Location', 'best');
+else
+    legend(strrep(configs, '_', ' '), 'Location', 'best');
+end
 grid on;
 
 sgtitle('Temporal Patterns in Active Mode Performance', 'FontSize', 14, 'FontWeight', 'bold');


### PR DESCRIPTION
## Summary
- compute `performance_trend_lower` and `performance_trend_upper` as the min and max of tight/leaky trends
- improve `plot_temporal_patterns` to handle missing data gracefully and shade using these bounds
- build legend handles dynamically so only plotted series appear in the legend

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888d9286c7083278fbd5a45e20ce1e1