### PR TITLE
Fix label duplication for stability plots

### DIFF
--- a/plot_temporal_patterns.m
+++ b/plot_temporal_patterns.m
@@ -64,7 +64,11 @@ for i = 1:length(configs)
         else
             stab_lower(i) = NaN; stab_upper(i) = NaN;
         end
-        labels{i} = sprintf('%s\n%s Filter', strrep(data.location, '_', ' '), upper(data.filterType));
+        % Use single-line labels combining location and filter type
+        % to avoid issues where newline characters create separate
+        % tick marks on some rendering backends.
+        labels{i} = sprintf('%s - %s Filter', ...
+            strrep(data.location, '_', ' '), upper(data.filterType));
     end
 end
 

--- a/plot_trigger_response_analysis.m
+++ b/plot_trigger_response_analysis.m
@@ -419,7 +419,10 @@ for i = 1:length(configs)
     data = temporalAnalysis.(config);
     if isfield(data, 'stability_score')
         stability_scores(i) = data.stability_score;
-        labels{i} = sprintf('%s\n%s Filter', strrep(data.location, '_', ' '), upper(data.filterType));
+        % Use single-line labels to clearly show both location and filter
+        % type, preventing duplicated tick marks on some backends.
+        labels{i} = sprintf('%s - %s Filter', ...
+            strrep(data.location, '_', ' '), upper(data.filterType));
     end
 end
 


### PR DESCRIPTION
## Summary
- clarify x-axis labels for temporal stability plots
- use single-line labels combining location and filter type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888dad01d5883279df3cd6ab5b78e0e