### PR TITLE
Sync event timeline definition

### DIFF
--- a/detect_intervention_events.m
+++ b/detect_intervention_events.m
@@ -1,0 +1,49 @@
+function events = detect_intervention_events(control_series, outdoor_series, time_vec, params)
+%DETECT_INTERVENTION_EVENTS Identify events based on intervention activation.
+% EVENTS = DETECT_INTERVENTION_EVENTS(CONTROL, OUTDOOR, TIME_VEC, PARAMS)
+% returns a structure array with the same fields as DETECT_OUTDOOR_EVENTS but
+% using the intervention control signal to determine start/end times. OUTDOOR is
+% used to locate the peak concentration within each activation period so that
+% subsequent metrics are aligned with outdoor peaks.
+
+if nargin < 3 || isempty(time_vec)
+    time_vec = (1:numel(control_series))';
+end
+if nargin < 4
+    params = struct();
+end
+
+control = logical(control_series(:));
+starts = find(diff([0; control]) == 1);
+ends = find(diff([control; 0]) == -1);
+if numel(ends) < numel(starts)
+    ends(end+1) = numel(control);
+end
+
+n = numel(starts);
+baseline = prctile(outdoor_series, 20);
+
+events = struct('start', {}, 'end', {}, 'duration', {}, ...
+                'peak_time', {}, 'peak_value', {}, 'baseline', {}, ...
+                'baseline_out', {}, 'start_time', {}, 'end_time', {}, ...
+                'peak_timestamp', {}, 'quality', {});
+
+for i = 1:n
+    s = starts(i);
+    e = ends(i);
+    win = s:e;
+    [~, idx] = max(outdoor_series(win));
+    pk = win(idx);
+    events(i).start = s;
+    events(i).end = e;
+    events(i).duration = e - s + 1;
+    events(i).peak_time = pk;
+    events(i).peak_value = outdoor_series(pk);
+    events(i).baseline = baseline;
+    events(i).baseline_out = baseline;
+    events(i).start_time = time_vec(s);
+    events(i).end_time = time_vec(e);
+    events(i).peak_timestamp = time_vec(pk);
+    events(i).quality = struct();
+end
+end

--- a/plot_trigger_response_analysis.m
+++ b/plot_trigger_response_analysis.m
@@ -122,7 +122,17 @@ if nargin >= 3 && ~isempty(activeData) && isfield(activeData, config)
         params = get_analysis_params();
     end
     tvec = (1:numel(series.outdoor_PM25))';
-    events = detect_outdoor_events(series.outdoor_PM25, tvec, 'PM2.5', params);
+    events = [];
+    if isfield(series, 'intervention_on')
+        events = detect_intervention_events(series.intervention_on, ...
+            series.outdoor_PM25, tvec, params);
+    elseif isfield(series, 'fan_status')
+        events = detect_intervention_events(series.fan_status, ...
+            series.outdoor_PM25, tvec, params);
+    else
+        events = detect_outdoor_events(series.outdoor_PM25, tvec, 'PM2.5', params);
+    end
+
     if ~isempty(events)
         eventTbl = compute_event_metrics_table(string(config), "PM2.5", events, ...
             series.outdoor_PM25(:), series.indoor_PM25_mean(:), params, tvec);
@@ -716,9 +726,11 @@ for i = 1:n
     end
 end
 
-xlabel('Hours Relative to Outdoor Peak');
-ylabel('Event Number');
-title(sprintf('Event Timeline - %s', strrep(configName,'_',' ')));
+    xlabel('Hours Relative to Outdoor Peak');
+    ylabel('Event Number');
+    yticks(1:n);
+    ylim([0 n+1]);
+    title(sprintf('Event Timeline - %s', strrep(configName,'_',' ')));
 legend({'Rise','Lag','Recovery'}, 'Location','best');
 grid on;
 end


### PR DESCRIPTION
## Summary
- detect events based on intervention activation if available
- render event indices as integers on event timeline

## Testing
- `apt-get update` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6888e7f13e4483278c18c9afb8d13418