### PR TITLE
Implement fixed-threshold event detection

### DIFF
--- a/detect_analyze_pollution_events.m
+++ b/detect_analyze_pollution_events.m
@@ -13,61 +13,52 @@ for i = 1:length(configs)
     eventAnalysis.(config).location = data.location;
     eventAnalysis.(config).filterType = data.filterType;
 
-    % Detect PM2.5 events in outdoor data
-    pm25_baseline = prctile(data.outdoor_PM25, params.baseline.percentile);
-    pm25_threshold = pm25_baseline * params.detection.threshold_multiplier_pm25;
-    pm25_events = find_pollution_events(data.outdoor_PM25, pm25_threshold, params.detection.min_duration_hours, params.detection.threshold_multiplier_pm25);
+    % Detect combined PM2.5/PM10 events based on fixed thresholds
+    pm25_threshold = 9.1;
+    pm10_threshold = 54;
 
-    % Detect PM10 events in outdoor data
-    pm10_baseline = prctile(data.outdoor_PM10, params.baseline.percentile);
-    pm10_threshold = pm10_baseline * params.detection.threshold_multiplier_pm10;
-    pm10_events = find_pollution_events(data.outdoor_PM10, pm10_threshold, params.detection.min_duration_hours, params.detection.threshold_multiplier_pm10);
+    combined_events = find_combined_events(data.outdoor_PM25, data.outdoor_PM10, ...
+        pm25_threshold, pm10_threshold, params.detection.min_duration_hours);
 
     % Bounds using tight and leaky indoor data
-    pm25_base_tight = prctile(data.indoor_PM25_tight, params.baseline.percentile);
-    pm25_base_leaky = prctile(data.indoor_PM25_leaky, params.baseline.percentile);
-    pm25_events_tight = find_pollution_events(data.indoor_PM25_tight, pm25_base_tight * params.detection.threshold_multiplier_pm25, params.detection.min_duration_hours, params.detection.threshold_multiplier_pm25);
-    pm25_events_leaky = find_pollution_events(data.indoor_PM25_leaky, pm25_base_leaky * params.detection.threshold_multiplier_pm25, params.detection.min_duration_hours, params.detection.threshold_multiplier_pm25);
+    events_tight = find_combined_events(data.indoor_PM25_tight, data.indoor_PM10_tight, ...
+        pm25_threshold, pm10_threshold, params.detection.min_duration_hours);
+    events_leaky = find_combined_events(data.indoor_PM25_leaky, data.indoor_PM10_leaky, ...
+        pm25_threshold, pm10_threshold, params.detection.min_duration_hours);
 
-    pm10_base_tight = prctile(data.indoor_PM10_tight, params.baseline.percentile);
-    pm10_base_leaky = prctile(data.indoor_PM10_leaky, params.baseline.percentile);
-    pm10_events_tight = find_pollution_events(data.indoor_PM10_tight, pm10_base_tight * params.detection.threshold_multiplier_pm10, params.detection.min_duration_hours, params.detection.threshold_multiplier_pm10);
-    pm10_events_leaky = find_pollution_events(data.indoor_PM10_leaky, pm10_base_leaky * params.detection.threshold_multiplier_pm10, params.detection.min_duration_hours, params.detection.threshold_multiplier_pm10);
+    total_tight = length(events_tight);
+    total_leaky = length(events_leaky);
 
-    total_tight = length(pm25_events_tight) + length(pm10_events_tight);
-    total_leaky = length(pm25_events_leaky) + length(pm10_events_leaky);
-
-    eventAnalysis.(config).pm25_events = pm25_events;
-    eventAnalysis.(config).pm10_events = pm10_events;
+    eventAnalysis.(config).combined_events = combined_events;
     eventAnalysis.(config).total_events = mean([total_tight, total_leaky]);
     eventAnalysis.(config).total_events_bounds = [min(total_tight, total_leaky), max(total_tight, total_leaky)];
 
     % Analyze event characteristics using indoor events for duration bounds
-    if ~isempty(pm25_events_tight)
-        dur_tight = mean([pm25_events_tight.duration]);
+    if ~isempty(events_tight)
+        dur_tight = mean([events_tight.duration]);
     else
         dur_tight = NaN;
     end
-    if ~isempty(pm25_events_leaky)
-        dur_leaky = mean([pm25_events_leaky.duration]);
+    if ~isempty(events_leaky)
+        dur_leaky = mean([events_leaky.duration]);
     else
         dur_leaky = NaN;
     end
 
     % Compute event severities for tight and leaky indoor cases
-    if ~isempty(pm25_events_tight)
-        severities_tight = [pm25_events_tight.peak_value] ./ [pm25_events_tight.baseline];
+    if ~isempty(events_tight)
+        severities_tight = [events_tight.peak_value] ./ [events_tight.baseline];
     else
         severities_tight = [];
     end
-    if ~isempty(pm25_events_leaky)
-        severities_leaky = [pm25_events_leaky.peak_value] ./ [pm25_events_leaky.baseline];
+    if ~isempty(events_leaky)
+        severities_leaky = [events_leaky.peak_value] ./ [events_leaky.baseline];
     else
         severities_leaky = [];
     end
 
-    if ~isempty(pm25_events)
-        severities = [pm25_events.peak_value] ./ [pm25_events.baseline];
+    if ~isempty(combined_events)
+        severities = [combined_events.peak_value] ./ [combined_events.baseline];
         eventAnalysis.(config).event_severities = severities;
         eventAnalysis.(config).event_severities_tight = severities_tight;
         eventAnalysis.(config).event_severities_leaky = severities_leaky;
@@ -76,7 +67,7 @@ for i = 1:length(configs)
         eventAnalysis.(config).avg_event_duration_bounds = [min(dur_tight, dur_leaky), max(dur_tight, dur_leaky)];
 
         % Analyze response to events
-        response_metrics = analyze_event_responses(pm25_events, data, params);
+        response_metrics = analyze_event_responses(combined_events, data, params);
         eventAnalysis.(config).pm25_response = response_metrics;
     else
         eventAnalysis.(config).avg_event_duration = NaN;

--- a/find_combined_events.m
+++ b/find_combined_events.m
@@ -1,0 +1,42 @@
+function events = find_combined_events(pm25_series, pm10_series, thr_pm25, thr_pm10, min_duration)
+%FIND_COMBINED_EVENTS Detect events where PM2.5 and PM10 exceed thresholds.
+%   EVENTS = FIND_COMBINED_EVENTS(PM25, PM10, THR_PM25, THR_PM10, MIN_DURATION)
+%   returns a structure array of events. An event begins when both PM25 and
+%   PM10 concentrations are simultaneously above the specified thresholds and
+%   ends once either pollutant drops below its threshold. MIN_DURATION
+%   specifies the minimum event length in samples.
+
+    if nargin < 5
+        min_duration = 1;
+    end
+
+    above = (pm25_series >= thr_pm25) & (pm10_series >= thr_pm10);
+    above(isnan(above)) = false;
+    starts = find(diff([false; above]) == 1);
+    ends   = find(diff([above; false]) == -1);
+
+    events = struct('start', {}, 'end', {}, 'duration', {}, ...
+                    'peak_time', {}, 'peak_value', {}, 'peak_pm10', {}, ...
+                    'baseline', {}, 'baseline_out', {});
+
+    for k = 1:numel(starts)
+        s = starts(k);
+        e = ends(k);
+        dur = e - s + 1;
+        if dur < min_duration
+            continue;
+        end
+        win = s:e;
+        [~, idx] = max(pm25_series(win) + pm10_series(win));
+        peak_idx = win(idx);
+        events(end+1) = struct( ...
+            'start', s, ...
+            'end', e, ...
+            'duration', dur, ...
+            'peak_time', peak_idx, ...
+            'peak_value', pm25_series(peak_idx), ...
+            'peak_pm10', pm10_series(peak_idx), ...
+            'baseline', thr_pm25, ...
+            'baseline_out', thr_pm25 );
+    end
+end


### PR DESCRIPTION
## Summary
- detect pollution events when PM2.5 ≥ 9.1 **and** PM10 ≥ 54
- add `find_combined_events` helper for joint pollutant detection
- update `detect_analyze_pollution_events` to use new method and compute metrics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a10366e1c8327b4c2539d73724bf2