### PR TITLE
Clarify indoor/outdoor labels on PM plots

### DIFF
--- a/plot_cumulative_exposure.m
+++ b/plot_cumulative_exposure.m
@@ -9,6 +9,14 @@ if nargin < 3 || isempty(pmField);  pmField  = 'indoor_PM25'; end
 if nargin < 4 || isempty(pmLabel);  pmLabel  = 'PM2.5';        end
 if nargin < 5 || isempty(fileName); fileName = 'cumulative_pm25_exposure.png'; end
 
+% Determine indoor/outdoor descriptor from pmField
+envLabel = '';
+if contains(lower(pmField), 'indoor')
+    envLabel = 'Indoor';
+elseif contains(lower(pmField), 'outdoor')
+    envLabel = 'Outdoor';
+end
+
 if isempty(summaryTable)
     warning('plot_cumulative_exposure: no data provided, skipping plot.');
     return;
@@ -58,12 +66,21 @@ for i = 1:height(uniqueConfigs)
     end
     title(sprintf('%s - %s', loc, filt));
     xlabel('Hour of Year');
-    ylabel(sprintf('Cumulative %s Exposure (µg/m³·h)', pmLabel));
+    if isempty(envLabel)
+        ylabel(sprintf('Cumulative %s Exposure (µg/m³·h)', pmLabel));
+    else
+        ylabel(sprintf('Cumulative %s %s Exposure (µg/m³·h)', envLabel, pmLabel));
+    end
     legend(legendEntries, 'Location','eastoutside');
     grid on;
 end
 
-sgtitle(sprintf('Cumulative Indoor %s Exposure Over Time', pmLabel));
+if isempty(envLabel)
+    sgTxt = sprintf('Cumulative %s Exposure Over Time', pmLabel);
+else
+    sgTxt = sprintf('Cumulative %s %s Exposure Over Time', envLabel, pmLabel);
+end
+sgtitle(sgTxt);
 save_figure(gcf, figuresDir, fileName);
 close(gcf);
 end

--- a/plot_cumulative_exposure_pm10.m
+++ b/plot_cumulative_exposure_pm10.m
@@ -2,5 +2,5 @@ function plot_cumulative_exposure_pm10(summaryTable, figuresDir)
 % Wrapper to plot cumulative indoor PM10 exposure
 % Uses plot_cumulative_exposure with PM10 data
 
-plot_cumulative_exposure(summaryTable, figuresDir, 'indoor_PM10', 'PM10', 'cumulative_pm10_exposure.png');
+plot_cumulative_exposure(summaryTable, figuresDir, 'indoor_PM10', 'PM10', 'indoor_cumulative_pm10_exposure.png');
 end

--- a/plot_efficiency_cost_quadrant.m
+++ b/plot_efficiency_cost_quadrant.m
@@ -70,7 +70,7 @@ text(x_median*1.5, y_median*1.5, 'High Cost, High Reduction', ...
 
 xlabel('% Indoor PM2.5 Reduction from Baseline');
 ylabel('Total Operational Cost ($)');
-title('Cost vs. PM2.5 Reduction Quadrant Map (with Uncertainty Regions)');
+title('Cost vs. Indoor PM2.5 Reduction Quadrant Map (with Uncertainty Regions)');
 grid on;
 legend('Location', 'eastoutside');
 

--- a/plot_efficiency_cost_quadrant_pm10.m
+++ b/plot_efficiency_cost_quadrant_pm10.m
@@ -58,7 +58,7 @@ set(hY, 'DisplayName', 'Median Cost');
 
 xlabel('% Indoor PM10 Reduction from Baseline');
 ylabel('Total Operational Cost ($)');
-title('Cost vs. PM10 Reduction Quadrant Map (with Uncertainty Regions)');
+title('Cost vs. Indoor PM10 Reduction Quadrant Map (with Uncertainty Regions)');
 grid on;
 legend('Location', 'eastoutside');
 

--- a/plot_pm10_envelope.m
+++ b/plot_pm10_envelope.m
@@ -4,5 +4,5 @@ function plot_pm10_envelope(summaryTable, figuresDir, showThresholds)
 if nargin < 3
     showThresholds = false;
 end
-plot_pm_envelope(summaryTable, figuresDir, 'indoor_PM10', 'PM10', 'pm10_envelope', showThresholds);
+plot_pm_envelope(summaryTable, figuresDir, 'indoor_PM10', 'PM10', 'indoor_pm10_envelope', showThresholds);
 end

--- a/plot_pm25_envelope.m
+++ b/plot_pm25_envelope.m
@@ -4,5 +4,5 @@ function plot_pm25_envelope(summaryTable, figuresDir, showThresholds)
 if nargin < 3
     showThresholds = false;
 end
-plot_pm_envelope(summaryTable, figuresDir, 'indoor_PM25', 'PM2.5', 'pm25_envelope', showThresholds);
+plot_pm_envelope(summaryTable, figuresDir, 'indoor_PM25', 'PM2.5', 'indoor_pm25_envelope', showThresholds);
 end

--- a/plot_pm_envelope.m
+++ b/plot_pm_envelope.m
@@ -7,6 +7,14 @@ if nargin < 4 || isempty(pmLabel), pmLabel = 'PM2.5'; end
 if nargin < 5 || isempty(prefix), prefix = 'pm25_envelope'; end
 if nargin < 6 || isempty(showThresholds), showThresholds = false; end
 
+% Determine indoor/outdoor descriptor based on the pmField name
+envLabel = '';
+if contains(lower(pmField), 'indoor')
+    envLabel = 'Indoor';
+elseif contains(lower(pmField), 'outdoor')
+    envLabel = 'Outdoor';
+end
+
 configs = unique(summaryTable(:, {'location','filterType'}));
 
 for i = 1:height(configs)
@@ -105,7 +113,11 @@ for i = 1:height(configs)
     end
 
     xlabel('Hour of Year');
-    ylabel(sprintf('%s Concentration (µg/m³)', pmLabel));
+    if isempty(envLabel)
+        ylabel(sprintf('%s Concentration (µg/m³)', pmLabel));
+    else
+        ylabel(sprintf('%s %s Concentration (µg/m³)', envLabel, pmLabel));
+    end
     title(sprintf('%s - %s: Hourly Concentration Bounds', loc, filt));
         legend(legendEntries, 'Location', 'best');
     grid on;
@@ -173,7 +185,11 @@ for i = 1:height(configs)
         end
     end
 
-    xlabel(sprintf('%s Concentration (µg/m³)', pmLabel));
+    if isempty(envLabel)
+        xlabel(sprintf('%s Concentration (µg/m³)', pmLabel));
+    else
+        xlabel(sprintf('%s %s Concentration (µg/m³)', envLabel, pmLabel));
+    end
     ylabel('Probability');
     title('Distribution Across Building Envelopes');
     legend(modes, 'Location','eastoutside');
@@ -213,8 +229,12 @@ for i = 1:height(configs)
     grid on;
 
     % Overall title
-    sgtitle(sprintf('Comprehensive %s Analysis: %s - %s Filter', pmLabel, loc, filt), ...
-        'FontSize',14,'FontWeight','bold');
+    if isempty(envLabel)
+        sgTitle = sprintf('Comprehensive %s Analysis: %s - %s Filter', pmLabel, loc, filt);
+    else
+        sgTitle = sprintf('Comprehensive %s %s Analysis: %s - %s Filter', envLabel, pmLabel, loc, filt);
+    end
+    sgtitle(sgTitle, 'FontSize',14,'FontWeight','bold');
     % Save
     % Build safe file name components with improved error handling
     locStr = regexprep(loc, '\s+', '_');


### PR DESCRIPTION
## Summary
- clarify indoor/outdoor in pm envelope plots
- note environment in cumulative exposure plots
- label indoor PM in efficiency vs cost plots
- prefix output filenames with `indoor_` for clarity

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `apt-get install -y octave` *(fails: ca-certificates-java error)*

------
https://chatgpt.com/codex/tasks/task_e_688a18667bb48327b9f604897454f0bd